### PR TITLE
Fix Python module output selector

### DIFF
--- a/js/pythonexec.js
+++ b/js/pythonexec.js
@@ -129,7 +129,7 @@ class PythonModule extends HTMLElement {
     this.tododiv = this.querySelector('[role="consignes"]');
     this.acediv = this.querySelector('[role="editor"]');
     this.pythondiv = this.querySelector('[role="result"]');
-    this.pythonoutput = this.querySelector('[role="output"');
+    this.pythonoutput = this.querySelector('[role="output"]');
     console.log(this.pythonoutput);
     this.pythonoutput.id = this.id + "Console";
     console.log(this.pythonoutput.id);


### PR DESCRIPTION
## Summary
- fix typo in `[role="output"]` selector to attach console element correctly

## Testing
- `python3 -m py_compile python/*.py`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a0b0a7e148322b0819ada51a5cf72